### PR TITLE
Refactor/get config is called multiple times

### DIFF
--- a/dist/features/PullRequestFileSize.d.ts
+++ b/dist/features/PullRequestFileSize.d.ts
@@ -1,2 +1,3 @@
 import { Context } from "probot";
-export declare const updatePullRequestWithFileSizeLabel: (context: Context<"pull_request">) => Promise<void>;
+import { Config } from "../shared/Config";
+export declare const updatePullRequestWithFileSizeLabel: (context: Context<"pull_request">, { files }: Config) => Promise<void>;

--- a/dist/features/PullRequestLinesChanged.d.ts
+++ b/dist/features/PullRequestLinesChanged.d.ts
@@ -1,2 +1,3 @@
 import { Context } from "probot";
-export declare const updatePullRequestWithLinesChangedLabel: (context: Context<"pull_request">) => Promise<void>;
+import { Config } from "../shared/Config";
+export declare const updatePullRequestWithLinesChangedLabel: (context: Context<"pull_request">, { lines }: Config) => Promise<void>;

--- a/dist/features/SetupLabels.d.ts
+++ b/dist/features/SetupLabels.d.ts
@@ -1,2 +1,3 @@
 import { Context } from "probot";
-export declare function setupLabels(context: Context<"pull_request">): Promise<void>;
+import { Config } from "../shared/Config";
+export declare function setupLabels(context: Context<"pull_request">, { lines, files }: Config): Promise<void>;

--- a/src/app.ts
+++ b/src/app.ts
@@ -19,12 +19,13 @@ export = (app: Probot) => {
 };
 
 async function updatePullRequest(context: Context<"pull_request">): Promise<void> {
-  const [{labels}] = await Promise.all([getConfig(context), setupLabels(context)]);
+  const config = await getConfig(context);
+  await Promise.all([setupLabels(context, config)]);
 
   const features: Promise<void>[] = [];
 
-  if (labels.files) features.push(updatePullRequestWithFileSizeLabel(context));
-  if (labels.lines) features.push(updatePullRequestWithLinesChangedLabel(context));
+  if (config.labels.files) features.push(updatePullRequestWithFileSizeLabel(context, config));
+  if (config.labels.lines) features.push(updatePullRequestWithLinesChangedLabel(context, config));
 
   await Promise.all(features);
 }

--- a/src/features/PullRequestFileSize.ts
+++ b/src/features/PullRequestFileSize.ts
@@ -1,10 +1,12 @@
 import {Context} from "probot";
 import addLabelsToPullRequest from "../shared/AddLabelsToPullRequest";
-import getConfig, {LabelSizeConfig} from "../shared/Config";
+import {Config, LabelSizeConfig} from "../shared/Config";
 import removePreviousSizeLabels from "../shared/RemovePreviousSizeLabels";
 
-export const updatePullRequestWithFileSizeLabel = async (context: Context<"pull_request">) => {
-  const {files} = await getConfig(context);
+export const updatePullRequestWithFileSizeLabel = async (
+  context: Context<"pull_request">,
+  {files}: Config
+) => {
   const filesChanged = context.payload.pull_request.changed_files;
   const label = getFilesChangedLabel(filesChanged, files);
 

--- a/src/features/PullRequestLinesChanged.ts
+++ b/src/features/PullRequestLinesChanged.ts
@@ -1,11 +1,13 @@
 import {Context} from "probot";
 import addLabelsToPullRequest from "../shared/AddLabelsToPullRequest";
-import getConfig, {LabelSizeConfig} from "../shared/Config";
+import {Config, LabelSizeConfig} from "../shared/Config";
 import removePreviousSizeLabels from "../shared/RemovePreviousSizeLabels";
 
-export const updatePullRequestWithLinesChangedLabel = async (context: Context<"pull_request">) => {
+export const updatePullRequestWithLinesChangedLabel = async (
+  context: Context<"pull_request">,
+  {lines}: Config
+) => {
   const linesChanged = getLinesChanged(context);
-  const {lines} = await getConfig(context);
   const label = await getLinesChangedLabel(linesChanged, lines);
 
   await Promise.all([

--- a/src/features/SetupLabels.ts
+++ b/src/features/SetupLabels.ts
@@ -1,10 +1,11 @@
 import {LabelSizeConfig, LabelSuffix} from "./../shared/Config";
 import {Context} from "probot";
-import getConfig from "../shared/Config";
+import {Config} from "../shared/Config";
 
-export async function setupLabels(context: Context<"pull_request">): Promise<void> {
-  const {lines, files} = await getConfig(context);
-
+export async function setupLabels(
+  context: Context<"pull_request">,
+  {lines, files}: Config
+): Promise<void> {
   await Promise.all([createLabels(lines, context), createLabels(files, context)]);
 }
 

--- a/test/features/PullRequestFileSize.test.ts
+++ b/test/features/PullRequestFileSize.test.ts
@@ -3,22 +3,15 @@ import {Context} from "probot";
 import {DEFAULT_CONFIG} from "../../src/shared/constants/DefaultConfig";
 import removePreviousSizeLabels from "../../src/shared/RemovePreviousSizeLabels";
 import addLabelsToPullRequest from "../../src/shared/AddLabelsToPullRequest";
-import getConfig from "../../src/shared/Config";
 import {FILES_LABEL_PREFIX} from "../utils/Constants";
 
 jest.mock("../../src/shared/RemovePreviousSizeLabels");
 jest.mock("../../src/shared/AddLabelsToPullRequest");
-jest.mock("../../src/shared/Config");
 
 const mockedRemovePreviousSizeLabels = jest.mocked(removePreviousSizeLabels);
 const mockedAddLabelsToPullRequest = jest.mocked(addLabelsToPullRequest);
-const mockedGetConfig = jest.mocked(getConfig);
 
 describe("pull request file size", () => {
-  beforeEach(() => {
-    mockedGetConfig.mockResolvedValue(DEFAULT_CONFIG);
-  });
-
   [
     {expectedLabel: "XXL", changedFiles: 100},
     {expectedLabel: "XXL", changedFiles: 61},
@@ -36,7 +29,7 @@ describe("pull request file size", () => {
     it(`should add label ${FILES_LABEL_PREFIX}${expectedLabel} when changed files is ${changedFiles}`, async () => {
       const context = buildPullRequestContext(changedFiles);
 
-      await target.updatePullRequestWithFileSizeLabel(context);
+      await target.updatePullRequestWithFileSizeLabel(context, DEFAULT_CONFIG);
 
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledTimes(1);
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledWith(context, [
@@ -48,7 +41,7 @@ describe("pull request file size", () => {
   it("should call removePreviousSizeLabels", async () => {
     const context = buildPullRequestContext(1);
 
-    await target.updatePullRequestWithFileSizeLabel(context);
+    await target.updatePullRequestWithFileSizeLabel(context, DEFAULT_CONFIG);
 
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledTimes(1);
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledWith(

--- a/test/features/PullRequestLinesChanged.test.ts
+++ b/test/features/PullRequestLinesChanged.test.ts
@@ -3,22 +3,15 @@ import {Context} from "probot";
 import {DEFAULT_CONFIG} from "../../src/shared/constants/DefaultConfig";
 import removePreviousSizeLabels from "../../src/shared/RemovePreviousSizeLabels";
 import addLabelsToPullRequest from "../../src/shared/AddLabelsToPullRequest";
-import getConfig from "../../src/shared/Config";
 import {LINES_LABEL_PREFIX} from "../utils/Constants";
 
 jest.mock("../../src/shared/RemovePreviousSizeLabels");
 jest.mock("../../src/shared/AddLabelsToPullRequest");
-jest.mock("../../src/shared/Config");
 
 const mockedRemovePreviousSizeLabels = jest.mocked(removePreviousSizeLabels);
 const mockedAddLabelsToPullRequest = jest.mocked(addLabelsToPullRequest);
-const mockedGetConfig = jest.mocked(getConfig);
 
 describe("pull request file size", () => {
-  beforeEach(() => {
-    mockedGetConfig.mockResolvedValue(DEFAULT_CONFIG);
-  });
-
   [
     {expectedLabel: "XXL", additions: 1000, deletions: 1000},
     {expectedLabel: "XXL", additions: 501, deletions: 500},
@@ -38,7 +31,7 @@ describe("pull request file size", () => {
     }`, async () => {
       const context = buildPullRequestContext(additions, deletions);
 
-      await target.updatePullRequestWithLinesChangedLabel(context);
+      await target.updatePullRequestWithLinesChangedLabel(context, DEFAULT_CONFIG);
 
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledTimes(1);
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledWith(context, [
@@ -50,7 +43,7 @@ describe("pull request file size", () => {
   it("should call removePreviousSizeLabels", async () => {
     const context = buildPullRequestContext(1, 1);
 
-    await target.updatePullRequestWithLinesChangedLabel(context);
+    await target.updatePullRequestWithLinesChangedLabel(context, DEFAULT_CONFIG);
 
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledTimes(1);
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledWith(

--- a/test/features/SetupLabels.test.ts
+++ b/test/features/SetupLabels.test.ts
@@ -1,0 +1,69 @@
+import {DEFAULT_CONFIG} from "./../../src/shared/constants/DefaultConfig";
+import * as target from "../../src/features/SetupLabels";
+import {Context} from "probot";
+import {OWNER, REPOSITORY, ISSUE_NUMBER} from "../utils/Constants";
+import {LabelSuffix} from "../../src/shared/Config";
+
+const mockedCreateLabel = jest.fn();
+const mockedUpdateLabel = jest.fn();
+
+const context = {
+  name: "pull_request",
+  id: "",
+  payload: {
+    repository: {
+      owner: {
+        login: OWNER,
+      },
+      name: REPOSITORY,
+    },
+    number: ISSUE_NUMBER,
+  },
+  octokit: {
+    issues: {
+      createLabel: mockedCreateLabel,
+      updateLabel: mockedUpdateLabel,
+    },
+  },
+} as unknown as Context<"pull_request">;
+const filesLabels = Object.values(LabelSuffix).map((suffix) => ({
+  name: `${DEFAULT_CONFIG.files.prefix}${suffix}`,
+  colour: DEFAULT_CONFIG.files.colours[suffix],
+}));
+const linesLabels = Object.values(LabelSuffix).map((suffix) => ({
+  name: `${DEFAULT_CONFIG.lines.prefix}${suffix}`,
+  colour: DEFAULT_CONFIG.lines.colours[suffix],
+}));
+const allLabels = [...filesLabels, ...linesLabels];
+
+describe("setup labels", () => {
+  it("should create labels if none exist", async () => {
+    await target.setupLabels(context, DEFAULT_CONFIG);
+
+    expect(mockedCreateLabel).toHaveBeenCalledTimes(12);
+    allLabels.forEach(({name, colour}) =>
+      expect(mockedCreateLabel).toHaveBeenCalledWith({
+        name,
+        color: colour.replace("#", ""),
+        owner: OWNER,
+        repo: REPOSITORY,
+      })
+    );
+  });
+
+  it("should update labels if they already exist", async () => {
+    mockedCreateLabel.mockRejectedValue("Already exists");
+
+    await target.setupLabels(context, DEFAULT_CONFIG);
+
+    expect(mockedUpdateLabel).toHaveBeenCalledTimes(12);
+    allLabels.forEach(({name, colour}) =>
+      expect(mockedUpdateLabel).toHaveBeenCalledWith({
+        name,
+        color: colour.replace("#", ""),
+        owner: OWNER,
+        repo: REPOSITORY,
+      })
+    );
+  });
+});


### PR DESCRIPTION
Fixes an issue where `getConfig` was being called in multiple places and adds tests for `SetupLabels`