### PR TITLE
Refactor/disable label creation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ features: # Control which labels are enabled
     lines: true
     files: true
     omitted: [] # Define any regexs for files/directories you wish to omit from being counter e.g. ".*.yarn/.*" will prevent any changes in the yarn folder from being counted
+    createLabels: true # Enable this only the first time, then change it to false
 
 lines: # Config for lines labels
     sizing: # Define lines changed breakpoints e.g. lines changed > 1000 is XXL

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,8 +20,9 @@ export = (app: Probot) => {
 
 async function updatePullRequest(context: Context<"pull_request">): Promise<void> {
   const config = await getConfig(context);
-  const features: Promise<void>[] = [setupLabels(context, config)];
+  const features: Promise<void>[] = [];
 
+  if (config.features.createLabels) features.push(setupLabels(context, config));
   if (config.features.files) features.push(updatePullRequestWithFileSizeLabel(context, config));
   if (config.features.lines) features.push(updatePullRequestWithLinesChangedLabel(context, config));
 

--- a/src/shared/Config.ts
+++ b/src/shared/Config.ts
@@ -11,6 +11,7 @@ interface Features {
   lines: boolean;
   files: boolean;
   omitted: string[];
+  createLabels: boolean;
 }
 
 export interface LabelSizeConfig {

--- a/src/shared/constants/DefaultConfig.ts
+++ b/src/shared/constants/DefaultConfig.ts
@@ -5,6 +5,7 @@ export const DEFAULT_CONFIG: Config = {
     lines: true,
     files: true,
     omitted: [],
+    createLabels: false
   },
   lines: {
     sizing: {


### PR DESCRIPTION
# Refactor/disable label creation by default
Disables label creation by default, can be enabled via flag.