### PR TITLE
Refactor/reduce number of calls made when omitted is enabled

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -3,6 +3,7 @@ import {Context, Probot} from "probot";
 import {updatePullRequestWithLinesChangedLabel} from "./features/PullRequestLinesChanged";
 import getConfig from "./shared/Config";
 import {setupLabels} from "./features/SetupLabels";
+import getFilesChanged, {PullRequestFile} from "./shared/GetFilesChanged";
 
 export = (app: Probot) => {
   app.on("pull_request.opened", async (context) => {
@@ -20,10 +21,18 @@ export = (app: Probot) => {
 
 async function updatePullRequest(context: Context<"pull_request">): Promise<void> {
   const config = await getConfig(context);
+
+  let changedFiles: PullRequestFile[] | false = false;
+  if (config.features.omitted.length !== 0) {
+    changedFiles = await getFilesChanged(context, config.features.omitted);
+  }
+
   const features: Promise<void>[] = [setupLabels(context, config)];
 
-  if (config.features.files) features.push(updatePullRequestWithFileSizeLabel(context, config));
-  if (config.features.lines) features.push(updatePullRequestWithLinesChangedLabel(context, config));
+  if (config.features.files)
+    features.push(updatePullRequestWithFileSizeLabel(context, config, changedFiles));
+  if (config.features.lines)
+    features.push(updatePullRequestWithLinesChangedLabel(context, config, changedFiles));
 
   await Promise.all(features);
 }

--- a/src/features/PullRequestFileSize.ts
+++ b/src/features/PullRequestFileSize.ts
@@ -1,14 +1,15 @@
 import {Context} from "probot";
 import addLabelsToPullRequest from "../shared/AddLabelsToPullRequest";
 import {Config, LabelSizeConfig} from "../shared/Config";
-import getFilesChanged from "../shared/GetFilesChanged";
+import {PullRequestFile} from "../shared/GetFilesChanged";
 import removePreviousSizeLabels from "../shared/RemovePreviousSizeLabels";
 
 export const updatePullRequestWithFileSizeLabel = async (
   context: Context<"pull_request">,
-  {files, features}: Config
+  {files}: Config,
+  changedFiles: PullRequestFile[] | false
 ) => {
-  const filesChanged = await calculateFilesChanged(context, features.omitted);
+  const filesChanged = await calculateFilesChanged(context, changedFiles);
   const label = getFilesChangedLabel(filesChanged, files);
 
   await Promise.all([
@@ -28,12 +29,11 @@ function getFilesChangedLabel(filesChanged: number, filesConfig: LabelSizeConfig
 
 async function calculateFilesChanged(
   context: Context<"pull_request">,
-  omitted: string[]
+  changedFiles: PullRequestFile[] | false
 ): Promise<number> {
-  if (omitted.length === 0) {
+  if (!changedFiles) {
     return context.payload.pull_request.changed_files;
   }
 
-  const filesChanged = await getFilesChanged(context, omitted);
-  return filesChanged.length;
+  return changedFiles.length;
 }

--- a/src/shared/GetFilesChanged.ts
+++ b/src/shared/GetFilesChanged.ts
@@ -50,4 +50,3 @@ export default async function getFilesChanged(
       .every((regex) => !regex.test(file.filename))
   );
 }
-

--- a/test/features/PullRequestFileSize.test.ts
+++ b/test/features/PullRequestFileSize.test.ts
@@ -4,15 +4,13 @@ import {DEFAULT_CONFIG} from "../../src/shared/constants/DefaultConfig";
 import removePreviousSizeLabels from "../../src/shared/RemovePreviousSizeLabels";
 import addLabelsToPullRequest from "../../src/shared/AddLabelsToPullRequest";
 import {FILES_LABEL_PREFIX} from "../utils/Constants";
-import getFilesChanged from "../../src/shared/GetFilesChanged";
+import {PullRequestFile} from "../../src/shared/GetFilesChanged";
 
 jest.mock("../../src/shared/RemovePreviousSizeLabels");
 jest.mock("../../src/shared/AddLabelsToPullRequest");
-jest.mock("../../src/shared/GetFilesChanged");
 
 const mockedRemovePreviousSizeLabels = jest.mocked(removePreviousSizeLabels);
 const mockedAddLabelsToPullRequest = jest.mocked(addLabelsToPullRequest);
-const mockedGetFilesChanged = jest.mocked(getFilesChanged);
 
 describe("pull request file size", () => {
   [
@@ -32,7 +30,7 @@ describe("pull request file size", () => {
     it(`should add label ${FILES_LABEL_PREFIX}${expectedLabel} when changed files is ${changedFiles}`, async () => {
       const context = buildPullRequestContext(changedFiles);
 
-      await target.updatePullRequestWithFileSizeLabel(context, DEFAULT_CONFIG);
+      await target.updatePullRequestWithFileSizeLabel(context, DEFAULT_CONFIG, false);
 
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledTimes(1);
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledWith(context, [
@@ -44,7 +42,7 @@ describe("pull request file size", () => {
   it("should call removePreviousSizeLabels", async () => {
     const context = buildPullRequestContext(1);
 
-    await target.updatePullRequestWithFileSizeLabel(context, DEFAULT_CONFIG);
+    await target.updatePullRequestWithFileSizeLabel(context, DEFAULT_CONFIG, false);
 
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledTimes(1);
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledWith(
@@ -55,14 +53,12 @@ describe("pull request file size", () => {
   });
 
   it("should call getFilesChanged when omitted exists", async () => {
-    mockedGetFilesChanged.mockResolvedValue([]);
     const context = buildPullRequestContext(1);
-    const config = Object.assign(DEFAULT_CONFIG, {features: {omitted: ["Test"]}});
+    const pullRequestFile = {} as PullRequestFile;
 
-    await target.updatePullRequestWithFileSizeLabel(context, config);
+    await target.updatePullRequestWithFileSizeLabel(context, DEFAULT_CONFIG, [pullRequestFile]);
 
-    expect(mockedGetFilesChanged).toHaveBeenCalledTimes(1);
-    expect(mockedGetFilesChanged).toHaveBeenCalledWith(context, config.features.omitted);
+    expect(mockedAddLabelsToPullRequest).toHaveBeenCalledWith(context, [`${FILES_LABEL_PREFIX}XS`]);
   });
 });
 

--- a/test/features/PullRequestLinesChanged.test.ts
+++ b/test/features/PullRequestLinesChanged.test.ts
@@ -4,15 +4,13 @@ import {DEFAULT_CONFIG} from "../../src/shared/constants/DefaultConfig";
 import removePreviousSizeLabels from "../../src/shared/RemovePreviousSizeLabels";
 import addLabelsToPullRequest from "../../src/shared/AddLabelsToPullRequest";
 import {LINES_LABEL_PREFIX} from "../utils/Constants";
-import getFilesChanged from "../../src/shared/GetFilesChanged";
+import {PullRequestFile} from "../../src/shared/GetFilesChanged";
 
 jest.mock("../../src/shared/RemovePreviousSizeLabels");
 jest.mock("../../src/shared/AddLabelsToPullRequest");
-jest.mock("../../src/shared/GetFilesChanged");
 
 const mockedRemovePreviousSizeLabels = jest.mocked(removePreviousSizeLabels);
 const mockedAddLabelsToPullRequest = jest.mocked(addLabelsToPullRequest);
-const mockedGetFilesChanged = jest.mocked(getFilesChanged);
 
 describe("pull request file size", () => {
   [
@@ -34,7 +32,7 @@ describe("pull request file size", () => {
     }`, async () => {
       const context = buildPullRequestContext(additions, deletions);
 
-      await target.updatePullRequestWithLinesChangedLabel(context, DEFAULT_CONFIG);
+      await target.updatePullRequestWithLinesChangedLabel(context, DEFAULT_CONFIG, false);
 
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledTimes(1);
       expect(mockedAddLabelsToPullRequest).toHaveBeenCalledWith(context, [
@@ -46,7 +44,7 @@ describe("pull request file size", () => {
   it("should call removePreviousSizeLabels", async () => {
     const context = buildPullRequestContext(1, 1);
 
-    await target.updatePullRequestWithLinesChangedLabel(context, DEFAULT_CONFIG);
+    await target.updatePullRequestWithLinesChangedLabel(context, DEFAULT_CONFIG, false);
 
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledTimes(1);
     expect(mockedRemovePreviousSizeLabels).toHaveBeenCalledWith(
@@ -57,14 +55,15 @@ describe("pull request file size", () => {
   });
 
   it("should call getFilesChanged when omitted exists", async () => {
-    mockedGetFilesChanged.mockResolvedValue([]);
     const context = buildPullRequestContext(1, 1);
-    const config = Object.assign(DEFAULT_CONFIG, {features: {omitted: ["Test"]}});
+    const pullRequestFile = {changes: 1001} as PullRequestFile;
 
-    await target.updatePullRequestWithLinesChangedLabel(context, config);
+    await target.updatePullRequestWithLinesChangedLabel(context, DEFAULT_CONFIG, [pullRequestFile]);
 
-    expect(mockedGetFilesChanged).toHaveBeenCalledTimes(1);
-    expect(mockedGetFilesChanged).toHaveBeenCalledWith(context, config.features.omitted);
+    expect(mockedAddLabelsToPullRequest).toHaveBeenCalledTimes(1);
+    expect(mockedAddLabelsToPullRequest).toHaveBeenCalledWith(context, [
+      `${LINES_LABEL_PREFIX}XXL`,
+    ]);
   });
 });
 


### PR DESCRIPTION
# Refactor/reduce number of calls made when omitted is enabled

Reduces the number of calls made by moving the `getFilesChanged` into `app.ts` so that it's only called once for all features.